### PR TITLE
Adjust the defaults based on sources experience

### DIFF
--- a/cmd/org-id-column-populator/README.md
+++ b/cmd/org-id-column-populator/README.md
@@ -11,18 +11,19 @@ make
 The database connection details can be specified on the command line:
 
 ```
-org-id-column-populator -H localhost -p 5432 -u insights -w insights -n cloud-connector -t connections -a account -o org_id -b 1
+org-id-column-populator -H localhost -p 5432 -u insights -w insights -n cloud-connector -t connections -a account -o org_id -b 1 --ean-translator-addr "http://translation-svc:8092"
 ```
 
 Or the database connection details can be pulled from the clowder config file:
 
 ```
-ACG_CONFIG=clowder.json org-id-column-populator -C -t connections -a account -o org_id -b 1
+ACG_CONFIG=clowder.json org-id-column-populator -C -t connections -a account -o org_id -b 1 --ean-translator-addr "http://translation-svc:8092"
 ```
 
 The table name (-t), account number column name (-a), org_id column name (-o) and batch size (-b) are configurable.
 
-The`TestBatchTranslator` implementation of the BatchTranslator interface is used by default.
+The`TestBatchTranslator` implementation of the BatchTranslator interface can be used by setting the
+`--ean-translator-addr` command line option to `test`.
 To use a real instance of the BatchTranslator, set the address of the translation service
 using the `--ean-translator-addr` command line option.
 

--- a/cmd/org-id-column-populator/main.go
+++ b/cmd/org-id-column-populator/main.go
@@ -102,9 +102,16 @@ func NewRootCommand(logger *logrus.Logger) *cobra.Command {
 	rootCmd.Flags().StringVarP(&prometheusPushGatewayAddr, "prometheus-push-addr", "g", "", "Address of prometheus push gateway")
 
 	rootCmd.Flags().StringVarP(&translatorServiceAddr, "ean-translator-addr", "T", "", "Address of EAN translator service")
-	rootCmd.MarkPersistentFlagRequired("ean-translator-addr")
 
 	rootCmd.Flags().IntVarP(&translatorServiceTimeout, "ean-translator-timeout", "O", 20, "Timeout for calling the EAN translator service")
+
+	requiredOptions := []string{"db-table-name", "db-account-column-name", "db-org-id-column-name", "ean-translator-addr"}
+	for _, requiredOption := range requiredOptions {
+		err := rootCmd.MarkFlagRequired(requiredOption)
+		if err != nil {
+			logger.Fatal(err)
+		}
+	}
 
 	return rootCmd
 }


### PR DESCRIPTION
- changed default batch size to 100
- changed default ean-translator timeout to 20 seconds
- make the ean-translator-addr command line option required (this can be set to "test" in order to use the test impl)